### PR TITLE
Use ruby 3.1 for version bump

### DIFF
--- a/.github/workflows/build_archive.yml
+++ b/.github/workflows/build_archive.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.4' 
       - name: Install dependencies
         run: gem install rake rake-version
       - name: Bump Version


### PR DESCRIPTION
The version bump gem uses the `File.exists?` which is not supported in ruby 3.2